### PR TITLE
Add README and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 lynnswap
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# HighlightrUI
+
+A Swift Package that provides SwiftUI views for syntax highlighted text editing using [Highlightr](https://github.com/raspu/Highlightr).
+
+This package targets **iOS 17** and **macOS 14** and offers:
+
+- `HighlightrTextView` &ndash; a SwiftUI wrapper around a text view with syntax highlighting
+- `HighlightrJSConsoleView` &ndash; a resizable JavaScript console view
+- Toolbar modifiers to make editing code more comfortable
+
+## Installation
+
+Add the following dependency to your `Package.swift`:
+
+```swift
+.package(url: "https://github.com/yourusername/HighlightrUI.git", from: "1.0.0")
+```
+
+and then import `HighlightrUI` where needed.
+
+## Example Usage
+
+```swift
+import HighlightrUI
+
+struct ContentView: View {
+    @State private var text = "console.log(\"Hello\")"
+
+    var body: some View {
+        HighlightrTextView(text: $text, language: "javascript")
+    }
+}
+```
+
+## License
+
+This project is released under the MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- add public-facing README with installation and usage information
- include MIT license

## Testing
- `swift package resolve` *(fails: unable to clone dependency due to networking restrictions)*