### PR TITLE
Refactor toolbar modifier

### DIFF
--- a/Sources/HighlightrUI/Modifiers/HighlightrTextSyncModifier.swift
+++ b/Sources/HighlightrUI/Modifiers/HighlightrTextSyncModifier.swift
@@ -1,0 +1,37 @@
+//
+//  HighlightrTextSyncModifier.swift
+//  PDHighlightr
+//
+//  Created by lynnswap on 2025/05/14.
+//
+
+import SwiftUI
+struct HighlightrTextSyncModifier: ViewModifier {
+    var model: HighlightrTextViewModel
+    @Binding var text: String
+
+    func body(content: Content) -> some View {
+        content
+            .task(id: text) { syncFromBinding(model) }
+            .onChange(of: model.text) { if model.text != text { text = model.text } }
+    }
+    private func syncFromBinding(_ model: HighlightrTextViewModel) {
+        if model.text != text {
+            model.setText(text, initial: true)
+        }
+    }
+}
+
+extension View {
+    func highlightrTextSync(
+        _ model: HighlightrTextViewModel,
+        text: Binding<String>
+    ) -> some View {
+        modifier(
+            HighlightrTextSyncModifier(
+                model: model,
+                text: text
+            )
+        )
+    }
+}

--- a/Sources/HighlightrUI/Modifiers/HighlightrToolbarModifier.swift
+++ b/Sources/HighlightrUI/Modifiers/HighlightrToolbarModifier.swift
@@ -7,7 +7,6 @@
 import SwiftUI
 struct HighlightrToolbarModifier: ViewModifier {
     var model:HighlightrTextViewModel
-    @Binding var text:String
     
     @State private var store = HighlightrStore.shared
     @Environment(\.colorScheme) private var colorScheme
@@ -41,18 +40,11 @@ struct HighlightrToolbarModifier: ViewModifier {
                     model.setTheme(theme)
                 }
             }
-            .task(id: text) { syncFromBinding(model) }
-            .onChange(of: model.text) { if model.text != text { text = model.text } }
             .onChange(of:colorScheme){
                 if theme == "default"{
                     model.setTheme(defaultTheme)
                 }
             }
-    }
-    private func syncFromBinding(_ model:HighlightrTextViewModel) {
-        if model.text != text {
-            model.setText(text, initial: true)
-        }
     }
     private var defaultTheme:String{
         colorScheme == .dark ? "paraiso-dark" : "paraiso-light"
@@ -60,13 +52,11 @@ struct HighlightrToolbarModifier: ViewModifier {
 }
 extension View {
     func highlightrToolbar(
-        _ model: HighlightrTextViewModel,
-        text:Binding<String>
+        _ model: HighlightrTextViewModel
     ) -> some View {
         modifier(
             HighlightrToolbarModifier(
-                model:model,
-                text:text
+                model:model
             )
         )
     }

--- a/Sources/HighlightrUI/Views/HighlightrJSConsoleView.swift
+++ b/Sources/HighlightrUI/Views/HighlightrJSConsoleView.swift
@@ -39,7 +39,8 @@ public struct HighlightrJSConsoleView:View{
                     frame.size.height = min(textView.contentSize.height,maxHeight)
                     textView.frame = frame
                 }
-            .highlightrToolbar(model, text: $text)
+            .highlightrToolbar(model)
+            .highlightrTextSync(model, text: $text)
         }else{
             Color.clear
                 .task{

--- a/Sources/HighlightrUI/Views/HighlightrTextView.swift
+++ b/Sources/HighlightrUI/Views/HighlightrTextView.swift
@@ -21,7 +21,8 @@ public struct HighlightrTextView: View{
         if let model {
             HighlightrTextViewRepresentable(model:model)
                 .padding(.leading,4)
-                .highlightrToolbar(model, text: $text)
+                .highlightrToolbar(model)
+                .highlightrTextSync(model, text: $text)
         }else{
             Color.clear
                 .task{


### PR DESCRIPTION
## Summary
- separate text sync into HighlightrTextSyncModifier
- keep HighlightrToolbarModifier focused on theme selection
- update text view implementations to use the new modifier

## Testing
- `swift build -c debug` *(fails: unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6857a712a9b08325ac58c409b7fbe4d6